### PR TITLE
Extract flash messages and review form into partials

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,18 +50,12 @@
     </header>
 
     <% if notice %>
-      <div class="alert alert-success alert-dismissible fade show mb-0" role="alert" aria-live="polite">
-        <%= notice %>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-      </div>
+      <%= render "shared/flash_alert", type: "success", message: notice %>
     <% end %>
 
     <% if alert %>
-      <div class="alert alert-danger alert-dismissible fade show mb-0" role="alert" aria-live="polite">
-        <%= alert %>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
-  <% end %>
+      <%= render "shared/flash_alert", type: "danger", message: alert %>
+    <% end %>
 
   <main role="main">
     <%= yield %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -41,43 +41,7 @@
         <hr>
 
         <% if user_signed_in? && !current_user.reviewable? %>
-          <div class="card shadow-sm">
-            <div class="card-body">
-              <h2 class="card-title mb-4">Leave a Review</h2>
-              <%= form_with(model: @new_review, data: { turbo: false, controller: "review-form", action: "submit->review-form#submit" }) do |form| %>
-
-                <%= form.hidden_field :reviewee_id, value: @freelancer.id %>
-
-                <div class="alert alert-danger d-none" data-review-form-target="error"></div>
-
-                <div class="mb-3" data-controller="star-rating">
-                  <label class="form-label fw-bold">Your Rating</label>
-
-                  <%= form.hidden_field :stars, value: 0, data: { star_rating_target: "input", review_form_target: "stars" } %>
-                  <div>
-                    <% (1..5).each do |i| %>
-                      <span
-                        data-star-rating-target="star"
-                        data-value="<%= i %>"
-                        data-action="click->star-rating#select mouseover->star-rating#highlight mouseout->star-rating#reset"
-                        style="cursor:pointer; font-size: 2rem;">
-                        ☆
-                      </span>
-                    <% end %>
-                  </div>
-                </div>
-
-                <div class="mb-3">
-                  <label class="form-label fw-bold">Your Review</label>
-                  <%= form.text_area :body, class: "form-control", rows: 4, data: { review_form_target: "body" }, placeholder: "Share your experience..." %>
-                </div>
-
-                <div class="d-grid">
-                  <%= form.submit "Submit Review", class: "btn btn-lg", style: "background-color: #028090; border-color: #028090; color: white;" %>
-                </div>
-              <% end %>
-            </div>
-          </div>
+          <%= render "reviews/form", new_review: @new_review, freelancer: @freelancer %>
         <% elsif user_signed_in? && current_user.reviewable? %>
           <p class="text-muted text-center py-4">Only clients can leave reviews.</p>
         <% else %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,0 +1,37 @@
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h2 class="card-title mb-4">Leave a Review</h2>
+    <%= form_with(model: new_review, data: { turbo: false, controller: "review-form", action: "submit->review-form#submit" }) do |form| %>
+
+      <%= form.hidden_field :reviewee_id, value: freelancer.id %>
+
+      <div class="alert alert-danger d-none" data-review-form-target="error"></div>
+
+      <div class="mb-3" data-controller="star-rating">
+        <label class="form-label fw-bold">Your Rating</label>
+
+        <%= form.hidden_field :stars, value: 0, data: { star_rating_target: "input", review_form_target: "stars" } %>
+        <div>
+          <% (1..5).each do |i| %>
+            <span
+              data-star-rating-target="star"
+              data-value="<%= i %>"
+              data-action="click->star-rating#select mouseover->star-rating#highlight mouseout->star-rating#reset"
+              style="cursor:pointer; font-size: 2rem;">
+              ☆
+            </span>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label fw-bold">Your Review</label>
+        <%= form.text_area :body, class: "form-control", rows: 4, data: { review_form_target: "body" }, placeholder: "Share your experience..." %>
+      </div>
+
+      <div class="d-grid">
+        <%= form.submit "Submit Review", class: "btn btn-lg", style: "background-color: #028090; border-color: #028090; color: white;" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_flash_alert.html.erb
+++ b/app/views/shared/_flash_alert.html.erb
@@ -1,0 +1,4 @@
+<div class="alert alert-<%= type %> alert-dismissible fade show mb-0" role="alert" aria-live="polite">
+  <%= message %>
+  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>


### PR DESCRIPTION
## Summary
Applies Helper Methods Part 3 themes from the Rails curriculum to RepBoard.

- **Flash messages:** Extracted the `notice`/`alert` rendering from `application.html.erb` into a shared `_flash_alert` partial. The partial takes `type` and `message` locals, eliminating structural duplication between the two flash blocks.
- **Review form:** Extracted the "Leave a Review" card from `profiles/show.html.erb` into a `reviews/_form` partial. Takes `new_review` and `freelancer` locals. Shrinks the show view considerably and positions the form for future reuse.
- **No changes to Bootstrap or Devise** — both were already in use and audited clean.

## Test plan
- [x] Flash notice renders green end-to-end (review submit flow)
- [x] Flash alert renders red end-to-end (unauthenticated `/dashboard` visit)
- [x] Review form renders correctly for signed-in clients
- [x] "Only clients can leave reviews" message renders for signed-in freelancers
- [x] "Sign in to leave a review" link renders for visitors
- [x] Review submission still works end-to-end